### PR TITLE
[Javascript] Add helper to generate array combinations

### DIFF
--- a/javascript/src/combinator.js
+++ b/javascript/src/combinator.js
@@ -1,0 +1,107 @@
+/**
+ * Finds all combinations of elements within a given collection
+ */
+class Combinator {
+  /**
+   * @param {array} array the array from which to find combinations
+   * @param {number} combinationSize the size of the combinations to search for
+   */
+  constructor(array, combinationSize) {
+    this.array = array;
+    this.combinationSize = combinationSize;
+  }
+
+  /**
+   * Generates all combinations of a given size for a given array.
+   *
+   * For example, with an array of ['a', 'b', 'c', 'd'] and a combination
+   * size of 3, you would expect to get back:
+   * [['a', 'b', 'c'], ['a', 'b', 'd'], ['a', 'c', 'd'], ['b', 'c', 'd']]
+   *
+   * @return {array} returns an array of arrays containing all combinations
+   */
+  findCombinations() {
+    const combinations = [];
+
+    let indices;
+
+    if (this.array.length < this.combinationSize) return [];
+
+    while (indices = this.getNextIndices(indices)) {
+      const newCombination = [];
+      indices.forEach((i) => newCombination.push(this.array[i]));
+      combinations.push(newCombination);
+    }
+    return combinations;
+  }
+
+  /**
+   * Receives the indices used for the last combination and works out what
+   * the next indices are.
+   *
+   * For example, where the array was of size 8, and the combination size
+   * was 4, it would return
+   * getNextIndices([0, 1, 2, 3]) => [0, 1, 2, 4]
+   * getNextIndices([0, 1, 2, 7]) => [0, 1, 3, 4]
+   * getNextIndices([0, 1, 6, 7]) => [0, 2, 3, 4]
+   * getNextIndices([0, 5, 6, 7]) => [1, 2, 3, 4]
+   * getNextIndices([4, 5, 6, 7]) => undefined
+   *
+   * @param {array} indices the indices used to generate the previous
+   * combination
+   * @return {?array} the next indices
+   */
+  getNextIndices(indices) {
+    if (!indices) {
+      return new Array(this.combinationSize).fill('').map((_, i) => i);
+    }
+
+    const columnNumberToIncrement = this.getColumnNumberToIncrement(indices);
+
+    if (columnNumberToIncrement === undefined) return;
+
+    this.recalculateIndices(indices, columnNumberToIncrement);
+
+    return indices;
+  }
+
+  /**
+   * When a column needs to be incremented, it usually means that the columns
+   * following that one will have their indices reduced.
+   *
+   * For example if [0, 5, 6, 7] becomes [1, 2, 3, 4], the first column is
+   * incremented, but then all the other columns have three subtracted.
+   *
+   * @param {array} indices the indices of the previous combination
+   * @param {number} columnNumberToIncrement
+   * @return {void} the indices are updated in place
+   */
+  recalculateIndices(indices, columnNumberToIncrement) {
+    const deductionFromLaterIndices =
+      columnNumberToIncrement + this.array.length -
+      indices[columnNumberToIncrement] - this.combinationSize - 1;
+
+    for (let i = columnNumberToIncrement + 1; i < this.combinationSize; i++) {
+      indices[i] -= deductionFromLaterIndices;
+    }
+    indices[columnNumberToIncrement] += 1;
+  }
+
+  /**
+   * Starting from the right, works out which column can be incremented
+   * based on its current index
+   *
+   * @param {array} indices the current indices
+   * @return {?number} the column to be incremented, if any
+   */
+  getColumnNumberToIncrement(indices) {
+    for (let i = 0; i < this.combinationSize; i++) {
+      const columnNumber = this.combinationSize - i - 1;
+      const maxColumnValue = this.array.length - i - 1;
+
+      if (indices[columnNumber] < maxColumnValue) return columnNumber;
+    }
+  }
+}
+
+module.exports = Combinator;

--- a/javascript/test/combinator.test.js
+++ b/javascript/test/combinator.test.js
@@ -1,0 +1,72 @@
+const Combinator = require('../src/combinator.js');
+
+[
+  {
+    description: 'when combination size is greater than array size',
+    combinationSize: 7,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [],
+  },
+  {
+    description: 'when combination size equals array size',
+    combinationSize: 6,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [['a', 'b', 'c', 'd', 'e', 'f']],
+  },
+  {
+    description: 'when combination size is 2',
+    combinationSize: 2,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [
+      ['a', 'b'], ['a', 'c'], ['a', 'd'], ['a', 'e'], ['a', 'f'], ['b', 'c'],
+      ['b', 'd'], ['b', 'e'], ['b', 'f'], ['c', 'd'], ['c', 'e'], ['c', 'f'],
+      ['d', 'e'], ['d', 'f'], ['e', 'f'],
+    ],
+  },
+  {
+    description: 'when combination size is 3',
+    combinationSize: 3,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [
+      ['a', 'b', 'c'], ['a', 'b', 'd'], ['a', 'b', 'e'], ['a', 'b', 'f'],
+      ['a', 'c', 'd'], ['a', 'c', 'e'], ['a', 'c', 'f'], ['a', 'd', 'e'],
+      ['a', 'd', 'f'], ['a', 'e', 'f'], ['b', 'c', 'd'], ['b', 'c', 'e'],
+      ['b', 'c', 'f'], ['b', 'd', 'e'], ['b', 'd', 'f'], ['b', 'e', 'f'],
+      ['c', 'd', 'e'], ['c', 'd', 'f'], ['c', 'e', 'f'], ['d', 'e', 'f'],
+    ],
+  },
+  {
+    description: 'when combination size is 4',
+    combinationSize: 4,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [
+      ['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'e'], ['a', 'b', 'c', 'f'],
+      ['a', 'b', 'd', 'e'], ['a', 'b', 'd', 'f'], ['a', 'b', 'e', 'f'],
+      ['a', 'c', 'd', 'e'], ['a', 'c', 'd', 'f'], ['a', 'c', 'e', 'f'],
+      ['a', 'd', 'e', 'f'], ['b', 'c', 'd', 'e'], ['b', 'c', 'd', 'f'],
+      ['b', 'c', 'e', 'f'], ['b', 'd', 'e', 'f'], ['c', 'd', 'e', 'f'],
+    ],
+  },
+  {
+    description: 'when combination size is 5',
+    combinationSize: 5,
+    array: ['a', 'b', 'c', 'd', 'e', 'f'],
+    expectedResult: [
+      ['a', 'b', 'c', 'd', 'e'], ['a', 'b', 'c', 'd', 'f'],
+      ['a', 'b', 'c', 'e', 'f'], ['a', 'b', 'd', 'e', 'f'],
+      ['a', 'c', 'd', 'e', 'f'], ['b', 'c', 'd', 'e', 'f'],
+    ],
+  },
+].forEach((spec) => {
+  describe(spec.description, () => {
+    let combinator;
+
+    beforeEach(() => {
+      combinator = new Combinator(spec.array, spec.combinationSize);
+    });
+
+    test('it returns expected result', () => {
+      expect(combinator.findCombinations()).toEqual(spec.expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
Given an array, and a combination size, generates all combinations of that size from the array

i.e.
```
new Combinator(['a', 'b', 'c', 'd', 'e'], 3).findCombinations();
=> [
  ['a', 'b', 'c'], ['a', 'b', 'd'], ['a', 'b', 'e'],
  ['a', 'c', 'd'], ['a', 'c', 'e'], ['a', 'd', 'e'],
  ['b', 'c', 'd'], ['b', 'c', 'e'], ['b', 'd', 'e'],
  ['c', 'd', 'e']
]
```